### PR TITLE
Adding Lumma C2 seizure NS

### DIFF
--- a/Lists/Domains/sinkholed_servers/sinkhole_ns_list.csv
+++ b/Lists/Domains/sinkholed_servers/sinkhole_ns_list.csv
@@ -60,3 +60,5 @@ sl-reverse.com
 suspended-domain.org
 this-domain-is-sinkholed-by.abuse.ch
 torpig-sinkhole.org
+ns911a.microsoftinternetsafety.net
+ns911b.microsoftinternetsafety.net


### PR DESCRIPTION
Microsoft appears to have added the nameservers `ns911a.microsoftinternetsafety.net` and `ns911b.microsoftinternetsafety.net` to all domains it seized as part of its legal action against Lumma Stealer [1].

It would be useful for these domains to be cataloged, considering that neither Microsoft nor the DOJ has released the list publicly.

[1] https://blogs.microsoft.com/on-the-issues/2025/05/21/microsoft-leads-global-action-against-favored-cybercrime-tool/