### PR TITLE
Add InnerWarden to Detection Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ I regularly update most of these lists after each tool i analyze in my [detectio
 - [Defender Resource](https://defenderresourcehub.info/)
 - [awesome-threat-detection](https://github.com/0x4D31/awesome-threat-detection)
 - [LOLOLFarm](https://lolol.farm/)
+- [InnerWarden](https://github.com/InnerWarden/innerwarden) - Autonomous Linux security agent with 38 eBPF hooks, 48 detectors, and real-time threat response
 
 </details>
 


### PR DESCRIPTION
Adds [InnerWarden](https://github.com/InnerWarden/innerwarden) to the Detection Resources section.

InnerWarden is an autonomous security agent for Linux with real-time host-based threat detection and automated response. It runs 38 eBPF kernel hooks for syscall-level visibility, 48 stateful detectors (rootkit, ransomware, reverse shell, DNS tunneling, credential stuffing, etc.), and 23 correlation rules with MITRE ATT&CK mapping. Written in Rust.