### PR TITLE
Add defend.network feed to Security News

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ I regularly update most of these lists after each tool i analyze in my [detectio
 - [Clément Notin Feed](https://clement.notin.org/feed.xml)
 - [crowdstrike counter adversary operations blog](https://www.crowdstrike.com/en-us/blog/category.counter-adversary-operations/)
 - [deepinstinct blog](https://www.deepinstinct.com/blog)
+- [defend.network feed](https://defend.network/feed.xml)
 - [detect.fyi](https://detect.fyi/)
 - [Detection engineering weekly](https://www.detectionengineering.net/)
 - [DFIR weekly news](https://thisweekin4n6.com/)


### PR DESCRIPTION
Adds [defend.network](https://defend.network)'s RSS feed to the **Security News** list.

defend.network is a free, no-login source publishing daily cyber threat briefings and weekly vulnerability reports, with every CVE cross-checked against NVD and the CISA KEV catalog. The feed is at https://defend.network/feed.xml.

Thanks for maintaining these lists!