### PR TITLE
Add AdversaryGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,7 @@ I regularly update most of these lists after each tool i analyze in my [detectio
 - [Linux Logs - auditd](https://packages.debian.org/sid/auditd)
 - [Linux Logs - SysmonForLinux](https://github.com/microsoft/SysmonForLinux)
 - [Linux Logs - kunai](https://github.com/kunai-project/kunai)
+- [CTI - AdversaryGraph](https://github.com/anpa1200/adversarygraph)
 - [CTI - OpenCTI](https://github.com/OpenCTI-Platform/opencti)
 - [CTI - MISP](https://github.com/MISP/MISP)
 - [Code analysis](https://github.com/semgrep/semgrep)


### PR DESCRIPTION
Adds AdversaryGraph to the CTI platform entries.

AdversaryGraph is a self-hosted CTI-to-detection platform for ATT&CK/ATLAS mapping, IOC enrichment, TTP comparison, and analyst reporting.

Validation: git diff --check.