### PR TITLE
Add Clankerusecase to Detection Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ I regularly update most of these lists after each tool i analyze in my [detectio
 - [Sigma](https://github.com/mthcht/sigma/tree/master/rules)
 - [Splunk Rules](https://research.splunk.com/detections/)
 - [Elastic Rules](https://github.com/elastic/detection-rules)
+- [Clankerusecase](https://clankerusecase.com)
 - [DFIR-Report Sigma-Rules](https://github.com/The-DFIR-Report/Sigma-Rules)
 - [JoeSecurity Sigma-Rules](https://github.com/joesecurity/sigma-rules/tree/master/rules)
 - [mdecrevoisier Sigma-Rules](https://github.com/mdecrevoisier/SIGMA-detection-rules)


### PR DESCRIPTION
Adds [Clankerusecase](https://clankerusecase.com) (repo: https://github.com/Virtualhaggis/usecaseintel) to Detection Resources.

Open-source, MIT-licensed library of 7,800+ MITRE ATT&CK-mapped detections generated from public threat-intel reporting — available in Defender KQL, Sentinel KQL, Sigma, Splunk SPL, Datadog, CrowdStrike Falcon, and AWS CloudWatch, all schema/syntax-validated. Matched the existing `- [Title](url)` format in the section.