### PR TITLE
Add Agent Threat Rules (ATR) to Detection Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ I regularly update most of these lists after each tool i analyze in my [detectio
 - [Sigma](https://github.com/mthcht/sigma/tree/master/rules)
 - [Splunk Rules](https://research.splunk.com/detections/)
 - [Elastic Rules](https://github.com/elastic/detection-rules)
+- [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - open detection rules for AI-agent & MCP attacks (prompt injection, tool poisoning, exfiltration), Sigma/YARA for the agent layer
 - [DFIR-Report Sigma-Rules](https://github.com/The-DFIR-Report/Sigma-Rules)
 - [JoeSecurity Sigma-Rules](https://github.com/joesecurity/sigma-rules/tree/master/rules)
 - [mdecrevoisier Sigma-Rules](https://github.com/mdecrevoisier/SIGMA-detection-rules)


### PR DESCRIPTION
Adds [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) under Detection Resources, alongside the Sigma / Splunk / Elastic rule repositories.

ATR is an open, MIT-licensed detection-rule set for AI-agent and MCP attacks (prompt injection, tool poisoning, context exfiltration) — the agent-layer analogue to the rulesets already listed. Each rule carries OWASP LLM/Agentic and MITRE ATLAS references, usable as detection ground-truth in SOC/CTI pipelines. Single link in the existing format.