### PR TITLE
Add Vigil (open source AI SOC) to SIEM/SOC/PurpleTeam list

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ I regularly update most of these lists after each tool i analyze in my [detectio
 - [Threat-Hunting with Splunk](https://github.com/mthcht/ThreatHunting-Keywords)
 - [Detection Lists](https://github.com/mthcht/awesome-lists/Lists)
 - [PurpleTeam atomics](https://github.com/redcanaryco/atomic-red-team)
+- [Vigil - Open source AI SOC](https://github.com/Vigil-SOC/vigil)
 
 </details> 
 


### PR DESCRIPTION
Adds one line to `### 🖥️ SIEM/SOC/PurpleTeam related`:

- [Vigil - Open source AI SOC](https://github.com/Vigil-SOC/vigil)

Vigil is an open source agentic AI SOC — Python agents for triage, investigation,
threat hunting, correlation, response, and forensics, playbooks defined as plain
Markdown files, and 30+ tool integrations over MCP. Apache 2.0, self-hostable,
no vendor account needed. Site: https://vigilsoc.org