### PR TITLE
Add Malwagon to Sandbox / Emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ I regularly update most of these lists after each tool i analyze in my [detectio
 - [joesandbox](https://www.joesandbox.com/analysispaged/0)
 - [filescan.io](https://www.filescan.io/)
 - [Hybrid Analysis](https://www.hybrid-analysis.com/)
+- [Malwagon](https://malwagon.com/)
 - [virustotal](https://www.virustotal.com)
 - [threat zone](https://app.threat.zone/scan)
 - [vmray](https://www.vmray.com/)


### PR DESCRIPTION
Adds Malwagon to the Sandbox / Emulation list.

It detonates a submitted file or URL on instrumented Windows and Linux virtual machines and returns process, registry, file and network behaviour with extracted indicators and ATT&CK technique mappings. A free community tier is available, alongside a REST API and a command line client, which fits the other entries in this section.